### PR TITLE
Remove exception_hierarchy.SafeException's overrides of the constructor ...

### DIFF
--- a/exception_hierarchy.py
+++ b/exception_hierarchy.py
@@ -148,10 +148,7 @@ class FileClosedError (FileError):
 
 class SafeException(RepyException):
     """Base class for Safe Exceptions"""
-    def __init__(self,*value):
-        self.value = str(value)
-    def __str__(self):
-        return self.value
+    pass
 
 class CheckNodeException(SafeException):
     """AST Node class is not in the whitelist."""


### PR DESCRIPTION
...and __str__ methods. Now we can use the __repr__, __str__, etc. inherited from Python's Exception class unmodified. See SeattleTestbed/repy_v2#74 .