### PR TITLE
Added cloning and copying of utf repo files

### DIFF
--- a/scripts/config_build.txt
+++ b/scripts/config_build.txt
@@ -7,5 +7,5 @@ DEPENDENCIES/seash/*
 DEPENDENCIES/common/*
 
 # Tests
-test DEPENDENCIES/common/utf/*
+test DEPENDENCIES/utf/*
 test testsV2/*

--- a/scripts/config_initialize.txt
+++ b/scripts/config_initialize.txt
@@ -3,3 +3,4 @@ https://github.com/SeattleTestbed/portability ../DEPENDENCIES/portability
 https://github.com/SeattleTestbed/seash ../DEPENDENCIES/seash
 https://github.com/SeattleTestbed/affix ../DEPENDENCIES/affix
 https://github.com/SeattleTestbed/common ../DEPENDENCIES/common
+https://github.com/SeattleTestbed/utf ../DEPENDENCIES/utf


### PR DESCRIPTION
'utf' directory is to be deleted from 'common' repo and to be cloned separately from its own repo.
Hence, build-scripts needs to be updated to reflect that change.
This PR takes care of that.