### PR TITLE
fixes for issue #95.  

### DIFF
--- a/encoding_header.py
+++ b/encoding_header.py
@@ -1,11 +1,8 @@
 """
-<Author>
-  Sebastien Awwad /:
+<Program Name>
+  encoding_header.py
 
-<Start Date>
-  March 18, 2016
-
-<Description>
+<Purpose>
   This mini module provides the ENCODING_DECLARATION constant, a string that is
   prepended to code loaded into VirtualNamespace objects. This is prepended to
   such code in order to specify UTF-8 encoding and prevent certain bugs.
@@ -15,17 +12,16 @@
   would raise such exceptions, so as to subtract the number of lines it
   contains from reported line numbers.
 
-  Consequently, multiple modules import this, and because they also depend on
-  each other, it was decided to keep this in its own separate module in order
-  to help avoid import loops.
+  While it may seem silly to have a module for a single constant, multiple
+  modules import this, and because they also depend on each other, it was
+  decided to keep this in its own separate module in order to help avoid import
+  loops. In time, we may find more such things to pull together.
   
   As of this writing, it is used by:
     virtual_namespace.py
     tracebackrepy.py
     safe_check.py
     safe.py
-
-  It is my hope to restructure this sensibly in time.
 
   For history relevant to the above, see SeattleTestbed/repy_v2#95 and #96.
 

--- a/encoding_header.py
+++ b/encoding_header.py
@@ -1,0 +1,36 @@
+"""
+<Author>
+  Sebastien Awwad /:
+
+<Start Date>
+  March 18, 2016
+
+<Description>
+  This mini module provides the ENCODING_DECLARATION constant, a string that is
+  prepended to code loaded into VirtualNamespace objects. This is prepended to
+  such code in order to specify UTF-8 encoding and prevent certain bugs.
+
+  Because prepending it to code results in distortions in reported line numbers
+  in tracebacks when exceptions occur, this constant is imported in files that
+  would raise such exceptions, so as to subtract the number of lines it
+  contains from reported line numbers.
+
+  Consequently, multiple modules import this, and because they also depend on
+  each other, it was decided to keep this in its own separate module in order
+  to help avoid import loops.
+  
+  As of this writing, it is used by:
+    virtual_namespace.py
+    tracebackrepy.py
+    safe_check.py
+    safe.py
+
+  It is my hope to restructure this sensibly in time.
+
+  For history relevant to the above, see SeattleTestbed/repy_v2#95 and #96.
+
+"""
+
+# Treat any user code as having UTF-8 encoding. For this, 
+# prepend this encoding string
+ENCODING_DECLARATION = "# coding: utf-8\n\n"

--- a/safe.py
+++ b/safe.py
@@ -108,9 +108,15 @@ import exception_hierarchy # This is for exception classes shared with traceback
 
 
 # virtual_namespace prepends a multiline ENCODING_DECLARATION to user 
-# code. We import it to adjust traceback line numbers accordingly 
-# (see SeattleTestbed/repy_v2#95).
-import virtual_namespace
+# code. This ENCODING_DECLARATION is imported from mini module encoding_header.
+# It has the effect of treating user code as having UTF-8 encoding, preventing
+# certain bugs. As a side effect, prepending this header to code also results
+# in traceback line numbers being off. To remedy this, we import the code
+# header in several modules so as to subtract the number of lines it contains
+# from such line counts. We place it in its own file so that it can be imported
+# by multiple files with interdependencies, to avoid import loops.
+# For more info, see SeattleTestbed/repy_v2#95 and #96.
+import encoding_header
 
 
 # Fix to make repy compatible with Python 2.7.2 on Ubuntu 11.10 (ticket #1049)
@@ -246,9 +252,10 @@ def _check_node(node):
     None
   """
   # First, account for the shift in line numbers due to the addition of a
-  # safety-minded code header (ENCODING_DECLARATION) in virtual_namespace.py.
-  # (This addresses issue SeattleTestbed/repy_v2#95.)
-  HEADERSIZE = len(virtual_namespace.ENCODING_DECLARATION.splitlines())
+  # safety-minded code header (ENCODING_DECLARATION) in virtual_namespace.py
+  # from encoding_header.py.
+  # (This addresses issue SeattleTestbed/repy_v2#95. See it for more info.)
+  HEADERSIZE = len(encoding_header.ENCODING_DECLARATION.splitlines())
 
   # Proceed with the node check.
 

--- a/safe.py
+++ b/safe.py
@@ -12,16 +12,18 @@
       are used and that no unsafe strings are present.
 
     Executing safe code
-      This is done by creating a dictionary with a key for each built-in function,
-      and then running the code using that dictionary as our 'context'.
+      This is done by creating a dictionary with a key for each built-in
+      function, and then running the code using that dictionary as our
+      'context'.
      
     SafeDict Class
       This is a dict that prevents 'unsafe' values from being added.
-      SafeDict is used by virtual_namespace (for the safe eval) as the dictionary
-      of variables that will be accessible to the running code. The reason it is
-      important to prevent unsafe keys is because it is possible to use them to
-      break out of the sandbox. For example, it is possible to change an objects
-      private variables by manually bypassing python's name mangling.
+      SafeDict is used by virtual_namespace (for the safe eval) as the
+      dictionary of variables that will be accessible to the running code. The
+      reason it is important to prevent unsafe keys is because it is possible
+      to use them to break out of the sandbox. For example, it is possible to
+      change an objects private variables by manually bypassing python's name
+      mangling.
 
   The original version of this file was written by Phil Hassey. it has since
   been heavily rewritten for use in the Seattle project.
@@ -228,9 +230,9 @@ _NODE_ATTR_OK = ['value']
 def _check_node(node):
   """
   <Purpose>
-    Examines a node, its attributes, and all of its children (recursively) for safety.
-    A node is safe if it is in _NODE_CLASS_OK and an attribute is safe if it is
-    not a unicode string and either in _NODE_ATTR_OK or is safe as is 
+    Examines a node, its attributes, and all of its children (recursively) for
+    safety. A node is safe if it is in _NODE_CLASS_OK and an attribute is safe
+    if it is not a unicode string and either in _NODE_ATTR_OK or is safe as is 
     defined by _is_string_safe()
   
   <Arguments>
@@ -251,12 +253,14 @@ def _check_node(node):
   # Proceed with the node check.
 
   if node.__class__.__name__ not in _NODE_CLASS_OK:
-    raise exception_hierarchy.CheckNodeException(node.lineno - HEADERSIZE, node.__class__.__name__)
+    raise exception_hierarchy.CheckNodeException(node.lineno - HEADERSIZE,
+      node.__class__.__name__)
   
   for attribute, value in node.__dict__.iteritems():
     # Don't allow the construction of unicode literals
     if type(value) == unicode:
-      raise exception_hierarchy.CheckStrException(node.lineno - HEADERSIZE, attribute, value)
+      raise exception_hierarchy.CheckStrException(node.lineno - HEADERSIZE,
+        attribute, value)
 
     if attribute in _NODE_ATTR_OK: 
       continue
@@ -269,7 +273,8 @@ def _check_node(node):
 
     # Check the safety of any strings
     if not _is_string_safe(value):
-      raise exception_hierarchy.CheckStrException(node.lineno - HEADERSIZE, attribute, value)
+      raise exception_hierarchy.CheckStrException(node.lineno - HEADERSIZE,
+        attribute, value)
 
   for child in node.getChildNodes():
     _check_node(child)
@@ -280,7 +285,8 @@ def safe_check(code):
   """
   <Purpose>
     Takes the code as input, and parses it into an AST.
-    It then calls _check_node, which does a recursive safety check for every node.
+    It then calls _check_node, which does a recursive safety check for every
+    node.
   
   <Arguments>
     code: A string representation of python code
@@ -303,9 +309,10 @@ def safe_check(code):
 def safe_check_subprocess(code):
   """
   <Purpose>
-    Runs safe_check() in a subprocess. This is done because the AST safe_check()
-    creates uses a large amount of RAM. By running safe_check() in a subprocess
-    we can guarantee that the memory will be reclaimed when the process ends.
+    Runs safe_check() in a subprocess. This is done because the AST
+    safe_check() uses a large amount of RAM. By running safe_check() in a
+    subprocess we can guarantee that the memory will be reclaimed when the
+    process ends.
   
   <Arguments>
     code: See safe_check.
@@ -321,7 +328,8 @@ def safe_check_subprocess(code):
   path_to_safe_check = os.path.join(repy_constants.REPY_START_DIR, "safe_check.py")
   
   # Start a safety check process, reading from the user code and outputing to a pipe we can read
-  proc = subprocess.Popen([sys.executable, path_to_safe_check],stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+  proc = subprocess.Popen([sys.executable, path_to_safe_check],
+                          stdin=subprocess.PIPE, stdout=subprocess.PIPE)
   
   # Write out the user code, close so the other end gets an EOF
   proc.stdin.write(code)

--- a/safe.py
+++ b/safe.py
@@ -243,9 +243,13 @@ def _check_node(node):
   <Return>
     None
   """
-  # Adjust line numbers to account for the encoding declaration header, 
-  # SeattleTestbed/repy_v2#95
+  # First, account for the shift in line numbers due to the addition of a
+  # safety-minded code header (ENCODING_DECLARATION) in virtual_namespace.py.
+  # (This addresses issue SeattleTestbed/repy_v2#95.)
   HEADERSIZE = len(virtual_namespace.ENCODING_DECLARATION.splitlines())
+
+  # Proceed with the node check.
+
   if node.__class__.__name__ not in _NODE_CLASS_OK:
     raise exception_hierarchy.CheckNodeException(node.lineno - HEADERSIZE, node.__class__.__name__)
   

--- a/safe.py
+++ b/safe.py
@@ -104,7 +104,7 @@ import subprocess   # This is to start the external process
 import __builtin__
 import nonportable  # This is to get the current runtime
 import repy_constants # This is to get our start-up directory
-import exception_hierarchy # For exception classes shared w/ tracebackrepy
+import exception_hierarchy # For exception classes
 import encoding_header # Subtract len(ENCODING_HEADER) from error line numbers.
 
 

--- a/safe.py
+++ b/safe.py
@@ -104,19 +104,8 @@ import subprocess   # This is to start the external process
 import __builtin__
 import nonportable  # This is to get the current runtime
 import repy_constants # This is to get our start-up directory
-import exception_hierarchy # This is for exception classes shared with tracebackrepy
-
-
-# virtual_namespace prepends a multiline ENCODING_DECLARATION to user 
-# code. This ENCODING_DECLARATION is imported from mini module encoding_header.
-# It has the effect of treating user code as having UTF-8 encoding, preventing
-# certain bugs. As a side effect, prepending this header to code also results
-# in traceback line numbers being off. To remedy this, we import the code
-# header in several modules so as to subtract the number of lines it contains
-# from such line counts. We place it in its own file so that it can be imported
-# by multiple files with interdependencies, to avoid import loops.
-# For more info, see SeattleTestbed/repy_v2#95 and #96.
-import encoding_header
+import exception_hierarchy # For exception classes shared w/ tracebackrepy
+import encoding_header # Subtract len(ENCODING_HEADER) from error line numbers.
 
 
 # Fix to make repy compatible with Python 2.7.2 on Ubuntu 11.10 (ticket #1049)

--- a/safe.py
+++ b/safe.py
@@ -236,13 +236,16 @@ def _check_node(node):
   <Return>
     None
   """
+  # need to adjust line numbers by 2 to account for the encoding specification 
+  # header (Issue #95)
+  HEADERSIZE = 2
   if node.__class__.__name__ not in _NODE_CLASS_OK:
-    raise exception_hierarchy.CheckNodeException(node.lineno,node.__class__.__name__)
+    raise exception_hierarchy.CheckNodeException(node.lineno-HEADERSIZE,node.__class__.__name__)
   
   for attribute, value in node.__dict__.iteritems():
     # Don't allow the construction of unicode literals
     if type(value) == unicode:
-      raise exception_hierarchy.CheckStrException(node.lineno, attribute, value)
+      raise exception_hierarchy.CheckStrException(node.lineno-HEADERSIZE, attribute, value)
 
     if attribute in _NODE_ATTR_OK: 
       continue
@@ -255,7 +258,7 @@ def _check_node(node):
 
     # Check the safety of any strings
     if not _is_string_safe(value):
-      raise exception_hierarchy.CheckStrException(node.lineno, attribute, value)
+      raise exception_hierarchy.CheckStrException(node.lineno-HEADERSIZE, attribute, value)
 
   for child in node.getChildNodes():
     _check_node(child)

--- a/safe.py
+++ b/safe.py
@@ -240,10 +240,8 @@ def _check_node(node):
   <Return>
     None
   """
-  # First, account for the shift in line numbers due to the addition of a
-  # safety-minded code header (ENCODING_DECLARATION) in virtual_namespace.py
-  # from encoding_header.py.
-  # (This addresses issue SeattleTestbed/repy_v2#95. See it for more info.)
+  # Subtract length of encoding header from traceback line numbers.
+  # (See Issue [SeattleTestbed/repy_v2#95])
   HEADERSIZE = len(encoding_header.ENCODING_DECLARATION.splitlines())
 
   # Proceed with the node check.

--- a/safe_check.py
+++ b/safe_check.py
@@ -11,7 +11,7 @@ Description:
 
 import safe
 import sys
-import encoding_header # Subtract len(ENCODING_HEADER) from error line numbers.
+import encoding_header
 
 
 
@@ -30,7 +30,7 @@ if __name__ == "__main__":
     # Adjust traceback line numbers. See Issue [SeattleTestbed/repy_v2#95].
     try:
       e.lineno = e.lineno - \
-                 len(encoding_header.ENCODING_DECLARATION.splitlines())
+          len(encoding_header.ENCODING_DECLARATION.splitlines())
     except AttributeError:
       # Some exceptions may not have line numbers.  If so, ignore
       pass

--- a/safe_check.py
+++ b/safe_check.py
@@ -13,9 +13,15 @@ import safe
 import sys
 
 # virtual_namespace prepends a multiline ENCODING_DECLARATION to user 
-# code. We import it to adjust traceback line numbers accordingly 
-# (see SeattleTestbed/repy_v2#95).
-import virtual_namespace
+# code. This ENCODING_DECLARATION is imported from mini module encoding_header.
+# It has the effect of treating user code as having UTF-8 encoding, preventing
+# certain bugs. As a side effect, prepending this header to code also results
+# in traceback line numbers being off. To remedy this, we import the code
+# header in several modules so as to subtract the number of lines it contains
+# from such line counts. We place it in its own file so that it can be imported
+# by multiple files with interdependencies, to avoid import loops.
+# For more info, see SeattleTestbed/repy_v2#95 and #96.
+import encoding_header
 
 
 
@@ -38,7 +44,8 @@ if __name__ == "__main__":
     # so that the line number we output corresponds with the actual 
     # user code again (see SeattleTestbed/repy_v2#95).
     try:
-      e.lineno = e.lineno - len(virtual_namespace.ENCODING_DECLARATION.splitlines())
+      e.lineno = e.lineno - \
+                 len(encoding_header.ENCODING_DECLARATION.splitlines())
     except AttributeError:
       # Some exceptions may not have line numbers.  If so, ignore
       pass

--- a/safe_check.py
+++ b/safe_check.py
@@ -24,6 +24,14 @@ if __name__ == "__main__":
     value = safe.safe_check(usercode)
     output += str(value)
   except Exception,e:
+    # To address issue #95, we need to subtract 2 from the line number.
+    # This compensates for adding the encoding information at the top of the
+    # file.
+    try:
+      e.lineno = e.lineno - 2
+    except AttributeError:
+      # Some exceptions may not have line numbers.  If so, ignore
+      pass
     output += str(type(e)) + " " + str(e)
   
   # Write out

--- a/safe_check.py
+++ b/safe_check.py
@@ -27,12 +27,7 @@ if __name__ == "__main__":
     value = safe.safe_check(usercode)
     output += str(value)
   except Exception, e:
-    # In virtual_namespace.py, we prepend an encoding declaration to 
-    # each user file we read in.
-    # Now, we need to subtract the number of lines consumed by the 
-    # encoding declaration from the current exception's line number 
-    # so that the line number we output corresponds with the actual 
-    # user code again (see SeattleTestbed/repy_v2#95).
+    # Adjust traceback line numbers. See Issue [SeattleTestbed/repy_v2#95].
     try:
       e.lineno = e.lineno - \
                  len(encoding_header.ENCODING_DECLARATION.splitlines())

--- a/safe_check.py
+++ b/safe_check.py
@@ -12,6 +12,13 @@ Description:
 import safe
 import sys
 
+# virtual_namespace prepends a multiline ENCODING_DECLARATION to user 
+# code. We import it to adjust traceback line numbers accordingly 
+# (see SeattleTestbed/repy_v2#95).
+import virtual_namespace
+
+
+
 if __name__ == "__main__":
   # Get the user "code"
   usercode = sys.stdin.read()
@@ -23,12 +30,15 @@ if __name__ == "__main__":
   try:
     value = safe.safe_check(usercode)
     output += str(value)
-  except Exception,e:
-    # To address issue #95, we need to subtract 2 from the line number.
-    # This compensates for adding the encoding information at the top of the
-    # file.
+  except Exception, e:
+    # In virtual_namespace.py, we prepend an encoding declaration to 
+    # each user file we read in.
+    # Now, we need to subtract the number of lines consumed by the 
+    # encoding declaration from the current exception's line number 
+    # so that the line number we output corresponds with the actual 
+    # user code again (see SeattleTestbed/repy_v2#95).
     try:
-      e.lineno = e.lineno - 2
+      e.lineno = e.lineno - len(virtual_namespace.ENCODING_DECLARATION.splitlines())
     except AttributeError:
       # Some exceptions may not have line numbers.  If so, ignore
       pass

--- a/safe_check.py
+++ b/safe_check.py
@@ -11,17 +11,7 @@ Description:
 
 import safe
 import sys
-
-# virtual_namespace prepends a multiline ENCODING_DECLARATION to user 
-# code. This ENCODING_DECLARATION is imported from mini module encoding_header.
-# It has the effect of treating user code as having UTF-8 encoding, preventing
-# certain bugs. As a side effect, prepending this header to code also results
-# in traceback line numbers being off. To remedy this, we import the code
-# header in several modules so as to subtract the number of lines it contains
-# from such line counts. We place it in its own file so that it can be imported
-# by multiple files with interdependencies, to avoid import loops.
-# For more info, see SeattleTestbed/repy_v2#95 and #96.
-import encoding_header
+import encoding_header # Subtract len(ENCODING_HEADER) from error line numbers.
 
 
 

--- a/testsV2/ut_errorlineno_codesafety.py
+++ b/testsV2/ut_errorlineno_codesafety.py
@@ -1,4 +1,0 @@
-#pragma out (4, 'Import')
-
-# code safety error on the next line
-import socket

--- a/testsV2/ut_errorlineno_codesafety.py
+++ b/testsV2/ut_errorlineno_codesafety.py
@@ -1,0 +1,4 @@
+#pragma out (4, 'Import')
+
+# code safety error on the next line
+import socket

--- a/testsV2/ut_errorlineno_codesafety.r2py
+++ b/testsV2/ut_errorlineno_codesafety.r2py
@@ -1,0 +1,6 @@
+#pragma repy
+#pragma out (6, 'Import')
+
+"""This unit test raises a code safety error on line 6. We do this to verify 
+that traceback line numbers are correct."""
+import socket

--- a/testsV2/ut_errorlineno_syntax.py
+++ b/testsV2/ut_errorlineno_syntax.py
@@ -1,3 +1,3 @@
 #pragma error line 3
 # syntax error on the next line
-sadfj asdkj afsdkj
+This is not a valid line of python.

--- a/testsV2/ut_errorlineno_syntax.py
+++ b/testsV2/ut_errorlineno_syntax.py
@@ -1,0 +1,3 @@
+#pragma error line 3
+# syntax error on the next line
+sadfj asdkj afsdkj

--- a/testsV2/ut_errorlineno_traceback.py
+++ b/testsV2/ut_errorlineno_traceback.py
@@ -1,0 +1,40 @@
+#pragma error line 40
+#pragma error line 31
+#pragma error line 38
+"""The traceback should look like this:
+Uncaught exception!
+---
+Following is a full traceback, and a user traceback.
+The user traceback excludes non-user modules. The most recent call is displayed last.
+
+Full debugging traceback:
+  "repy.py", line 154, in execute_namespace_until_completion
+  "/Users/justincappos/seattle/repy_v2/RUNNABLE/virtual_namespace.py", line 124, in evaluate
+  "/Users/justincappos/seattle/repy_v2/RUNNABLE/safe.py", line 591, in safe_run
+  "RepyV2:ut_errorlineno_traceback.py", line 40, in <module>
+  "RepyV2:ut_errorlineno_traceback.py", line 31, in foo
+  "RepyV2:ut_errorlineno_traceback.py", line 38, in bar
+
+User traceback:
+  "RepyV2:ut_errorlineno_traceback.py", line 40, in <module>
+  "RepyV2:ut_errorlineno_traceback.py", line 31, in foo
+  "RepyV2:ut_errorlineno_traceback.py", line 38, in bar
+
+Exception (with type 'exceptions.TypeError'): unsupported operand type(s) for +: 'int' and 'str'
+---
+
+"""
+
+# Check that the traceback's line numbers are also adjusted...
+
+def foo():
+  bar()  # 31st line
+
+
+def bar():
+  a = 3
+  b = 's'
+  # type error on the next line
+  c = a + b    # 38th line
+
+foo()   # This is the 40th line

--- a/testsV2/ut_errorlineno_typeerror.py
+++ b/testsV2/ut_errorlineno_typeerror.py
@@ -1,0 +1,6 @@
+#pragma error line 5
+a = 3
+b = 's'
+# type error on the next line
+c = a + b
+

--- a/tracebackrepy.py
+++ b/tracebackrepy.py
@@ -44,11 +44,18 @@ import exception_hierarchy
 # needed to get the PID
 import os
 
-# Armon: These set contains all the module's which are black-listed
+# Armon: These set contains all the modules which are black-listed
 # from the traceback, so that if there is an exception, they will
-# not appear in the stack.
-TB_SKIP_MODULES = ["repy.py","safe.py","virtual_namespace.py","namespace.py","emulcomm.py",
-                      "emultimer.py","emulmisc.py","emulfile.py","nonportable.py","socket.py"]
+# not appear in the "user" (filtered) traceback.
+TB_SKIP_MODULES = ["repy.py", "safe.py", "virtual_namespace.py", 
+    "namespace.py", "emulcomm.py", "emultimer.py", "emulmisc.py", 
+    "emulfile.py", "nonportable.py", "socket.py"]
+
+
+# Import virtual_namespace so that we can refer to the encoding declaration 
+# that is prepended to user code. We adjust traceback line numbers 
+# accordingly (see SeattleTestbed/repy_v2#95).
+import virtual_namespace
 
 
 # sets the user's file name.
@@ -73,6 +80,13 @@ def format_exception():
   <Side Effects>
     Calls sys.exc_clear(), so that we know this current exception has been
     "handled".
+
+    NOTE WELL:
+      Ensure that this function does not raise excpetions itself (even 
+      if it handles them). This will override the original exception 
+      we are trying to handle, and `sys.exc_info` / `sys.exc_clear` will 
+      not do the right thing. For reference, see the Python 2 docs:
+      https://docs.python.org/2.7/library/sys.html#sys.exc_info
 
   <Returns>
     A human readable string containing debugging information. Returns
@@ -112,46 +126,29 @@ def format_exception():
   # Check if there is an exception
   if exceptiontype is None:
     return None
- 
-  # Need to adjust if this is a file we added encoding information to (Issue 
-  # #95)
-  try:
-    if exceptionvalue.filename.startswith('RepyV2:'):
-      exceptionvalue.lineno = exceptionvalue.lineno - 2
-  except AttributeError:
-    # If there isn't a lineno or filename field, then do not try to tweak
-    # the line number of the exception
-    pass
 
   # We store a full traceback, and a "filtered" user traceback to help the user
   full_tb = ""
   filtered_tb = ""
 
-  for tracebackentry in traceback.extract_tb(exceptiontraceback):
-    # the entry format is (filename, lineno, modulename, linedata)
+  for (filename, lineno, modulename, _) in traceback.extract_tb(exceptiontraceback):
     # linedata is always empty because we prevent the linecache from working
     # for safety reasons...
 
     # Check that this module is not black-listed
-    module = tracebackentry[0]
     skip = False
 
-    # Check if any of the forbidden modules are a substring of the module name
-    # e.g. if the name is /home/person/seattle/repy.py, we want to see that repy.py
-    # and skip this frame.
+    # Check if any of the forbidden modules are a substring of the file name
+    # e.g. if the name is /home/person/seattle/repy.py, we want to see 
+    # that repy.py and skip this frame.
     for forbidden in TB_SKIP_MODULES:
-      if forbidden in module:
+      if forbidden in filename:
         skip = True
         break
 
-    # Construct a frame of output
-    # We need to subtract 2 lines to those files that Repy processed 
-    # (issue #95).  These files will seem to have a name that begins with
-    # 'RepyV2'.
-    if module.startswith('RepyV2:'):
-      stack_frame = '  "'+tracebackentry[0]+'", line '+str(tracebackentry[1]-2)+", in "+str(tracebackentry[2])+"\n"
-    else:
-      stack_frame = '  "'+tracebackentry[0]+'", line '+str(tracebackentry[1])+", in "+str(tracebackentry[2])+"\n"
+    # Construct a frame of output.
+    # Adjust traceback line numbers, see SeattleTestbed/repy_v2#95.
+    stack_frame = '  "' + filename + '", line ' + str(lineno - len(virtual_namespace.ENCODING_DECLARATION.splitlines())) + ", in " + modulename + "\n"
 
     # Always add to the full traceback
     full_tb += stack_frame

--- a/tracebackrepy.py
+++ b/tracebackrepy.py
@@ -44,9 +44,9 @@ import exception_hierarchy
 # needed to get the PID
 import os
 
-# Armon: These set contains all the modules which are black-listed
-# from the traceback, so that if there is an exception, they will
-# not appear in the "user" (filtered) traceback.
+# This list contains all the modules which are black-listed from the
+# traceback, so that if there is an exception, they will not appear in the
+# "user" (filtered) traceback.
 TB_SKIP_MODULES = ["repy.py", "safe.py", "virtual_namespace.py", 
     "namespace.py", "emulcomm.py", "emultimer.py", "emulmisc.py", 
     "emulfile.py", "nonportable.py", "socket.py"]

--- a/tracebackrepy.py
+++ b/tracebackrepy.py
@@ -34,15 +34,10 @@ servicelog = False
 # when deciding where to write our service log.
 logdirectory = None
 
-
-# We need to be able to do a harshexit on internal errors.
-import harshexit
-
-# Get the exception hierarchy
+import harshexit # We need to be able to do a harshexit on internal errors.
 import exception_hierarchy
-
-# needed to get the PID
-import os
+import os # needed to get the PID
+import encoding_header # Subtract len(ENCODING_HEADER) from error line numbers.
 
 # This list contains all the modules which are black-listed from the
 # traceback, so that if there is an exception, they will not appear in the
@@ -51,17 +46,6 @@ TB_SKIP_MODULES = ["repy.py", "safe.py", "virtual_namespace.py",
     "namespace.py", "emulcomm.py", "emultimer.py", "emulmisc.py", 
     "emulfile.py", "nonportable.py", "socket.py"]
 
-
-# virtual_namespace prepends a multiline ENCODING_DECLARATION to user 
-# code. This ENCODING_DECLARATION is imported from mini module encoding_header.
-# It has the effect of treating user code as having UTF-8 encoding, preventing
-# certain bugs. As a side effect, prepending this header to code also results
-# in traceback line numbers being off. To remedy this, we import the code
-# header in several modules so as to subtract the number of lines it contains
-# from such line counts. We place it in its own file so that it can be imported
-# by multiple files with interdependencies, to avoid import loops.
-# For more info, see SeattleTestbed/repy_v2#95 and #96.
-import encoding_header
 
 
 # sets the user's file name.

--- a/tracebackrepy.py
+++ b/tracebackrepy.py
@@ -113,6 +113,16 @@ def format_exception():
   if exceptiontype is None:
     return None
  
+  # Need to adjust if this is a file we added encoding information to (Issue 
+  # #95)
+  try:
+    if exceptionvalue.filename.startswith('RepyV2:'):
+      exceptionvalue.lineno = exceptionvalue.lineno - 2
+  except AttributeError:
+    # If there isn't a lineno or filename field, then do not try to tweak
+    # the line number of the exception
+    pass
+
   # We store a full traceback, and a "filtered" user traceback to help the user
   full_tb = ""
   filtered_tb = ""
@@ -135,7 +145,13 @@ def format_exception():
         break
 
     # Construct a frame of output
-    stack_frame = '  "'+tracebackentry[0]+'", line '+str(tracebackentry[1])+", in "+str(tracebackentry[2])+"\n"
+    # We need to subtract 2 lines to those files that Repy processed 
+    # (issue #95).  These files will seem to have a name that begins with
+    # 'RepyV2'.
+    if module.startswith('RepyV2:'):
+      stack_frame = '  "'+tracebackentry[0]+'", line '+str(tracebackentry[1]-2)+", in "+str(tracebackentry[2])+"\n"
+    else:
+      stack_frame = '  "'+tracebackentry[0]+'", line '+str(tracebackentry[1])+", in "+str(tracebackentry[2])+"\n"
 
     # Always add to the full traceback
     full_tb += stack_frame

--- a/tracebackrepy.py
+++ b/tracebackrepy.py
@@ -52,10 +52,16 @@ TB_SKIP_MODULES = ["repy.py", "safe.py", "virtual_namespace.py",
     "emulfile.py", "nonportable.py", "socket.py"]
 
 
-# Import virtual_namespace so that we can refer to the encoding declaration 
-# that is prepended to user code. We adjust traceback line numbers 
-# accordingly (see SeattleTestbed/repy_v2#95).
-import virtual_namespace
+# virtual_namespace prepends a multiline ENCODING_DECLARATION to user 
+# code. This ENCODING_DECLARATION is imported from mini module encoding_header.
+# It has the effect of treating user code as having UTF-8 encoding, preventing
+# certain bugs. As a side effect, prepending this header to code also results
+# in traceback line numbers being off. To remedy this, we import the code
+# header in several modules so as to subtract the number of lines it contains
+# from such line counts. We place it in its own file so that it can be imported
+# by multiple files with interdependencies, to avoid import loops.
+# For more info, see SeattleTestbed/repy_v2#95 and #96.
+import encoding_header
 
 
 # sets the user's file name.
@@ -148,7 +154,9 @@ def format_exception():
 
     # Construct a frame of output.
     # Adjust traceback line numbers, see SeattleTestbed/repy_v2#95.
-    stack_frame = '  "' + filename + '", line ' + str(lineno - len(virtual_namespace.ENCODING_DECLARATION.splitlines())) + ", in " + modulename + "\n"
+    stack_frame = '  "' + filename + '", line ' + \
+      str(lineno - len(encoding_header.ENCODING_DECLARATION.splitlines())) + \
+      ", in " + modulename + "\n"
 
     # Always add to the full traceback
     full_tb += stack_frame

--- a/virtual_namespace.py
+++ b/virtual_namespace.py
@@ -66,8 +66,15 @@ class VirtualNamespace(object):
     code = code.replace('\r\n','\n')
 
     # Prepend an encoding string to protect against bugs in that code (ticket #982)
-    # Note that this will cause tracebacks to have an inaccurate line number.
     code = "# coding: utf-8\n\n" + code 
+
+    # Witheout further fixes, this will cause tracebacks to have an inaccurate 
+    # line number. (This is issue #95 for repy_v2.)   We will prepend 
+    # 'RepyV2:' to the file names imported by repy.  This will serve as an 
+    # indicator that we have done this replacement (and that the traceback
+    # module should remove 2 lines from the count).
+    name = 'RepyV2:' + name
+    
 
     # Do a safety check
     try:

--- a/virtual_namespace.py
+++ b/virtual_namespace.py
@@ -72,7 +72,10 @@ class VirtualNamespace(object):
     # Prepend an encoding string to protect against bugs in that code (#982).
     # Without further fixes, prepending the encoding string causes tracebacks 
     # to have an inaccurate line number, see SeattleTestbed/repy_v2#95.
-    # We work around this in tracebackrepy.py
+    # Note that we work around this in tracebackrepy.py, safe.py, and
+    # safe_check.py by retrieving the length of
+    # virtual_namespace.ENCODING_DECLARATION and subtracting it from reported
+    # line numbers.
     code = ENCODING_DECLARATION + code 
 
 

--- a/virtual_namespace.py
+++ b/virtual_namespace.py
@@ -11,9 +11,16 @@
   specified global context.
 """
 
-# Treat any user code as having UTF-8 encoding. For this, 
-# prepend this encoding string
-ENCODING_DECLARATION = "# coding: utf-8\n\n"
+# encoding_header contains a multi-line ENCODING_DECLARATION that is to be
+# prepended to user code loaded into an instantiated VirtualNamespace.
+# It has the effect of treating user code as having UTF-8 encoding, preventing
+# certain bugs. As a side effect, prepending this header to code also results
+# in traceback line numbers being off. To remedy this, we import the code
+# header in several modules so as to subtract the number of lines it contains
+# from such line counts. We place it in its own file so that it can be imported
+# by multiple files with interdependencies, to avoid import loops.
+# For more info, see SeattleTestbed/repy_v2#95 and #96.
+import encoding_header
 
 # Used for safety checking
 import safe
@@ -76,7 +83,7 @@ class VirtualNamespace(object):
     # safe_check.py by retrieving the length of
     # virtual_namespace.ENCODING_DECLARATION and subtracting it from reported
     # line numbers.
-    code = ENCODING_DECLARATION + code 
+    code = encoding_header.ENCODING_DECLARATION + code 
 
 
     # Do a safety check

--- a/virtual_namespace.py
+++ b/virtual_namespace.py
@@ -11,21 +11,8 @@
   specified global context.
 """
 
-# encoding_header contains a multi-line ENCODING_DECLARATION that is to be
-# prepended to user code loaded into an instantiated VirtualNamespace.
-# It has the effect of treating user code as having UTF-8 encoding, preventing
-# certain bugs. As a side effect, prepending this header to code also results
-# in traceback line numbers being off. To remedy this, we import the code
-# header in several modules so as to subtract the number of lines it contains
-# from such line counts. We place it in its own file so that it can be imported
-# by multiple files with interdependencies, to avoid import loops.
-# For more info, see SeattleTestbed/repy_v2#95 and #96.
-import encoding_header
-
-# Used for safety checking
-import safe
-
-# Get the errors
+import encoding_header # Subtract len(ENCODING_HEADER) from error line numbers.
+import safe # Used for safety checking
 from exception_hierarchy import *
 
 # This is to work around safe...

--- a/virtual_namespace.py
+++ b/virtual_namespace.py
@@ -11,6 +11,10 @@
   specified global context.
 """
 
+# Treat any user code as having UTF-8 encoding. For this, 
+# prepend this encoding string
+ENCODING_DECLARATION = "# coding: utf-8\n\n"
+
 # Used for safety checking
 import safe
 
@@ -65,16 +69,12 @@ class VirtualNamespace(object):
     # Remove any windows carriage returns
     code = code.replace('\r\n','\n')
 
-    # Prepend an encoding string to protect against bugs in that code (ticket #982)
-    code = "# coding: utf-8\n\n" + code 
+    # Prepend an encoding string to protect against bugs in that code (#982).
+    # Without further fixes, prepending the encoding string causes tracebacks 
+    # to have an inaccurate line number, see SeattleTestbed/repy_v2#95.
+    # We work around this in tracebackrepy.py
+    code = ENCODING_DECLARATION + code 
 
-    # Witheout further fixes, this will cause tracebacks to have an inaccurate 
-    # line number. (This is issue #95 for repy_v2.)   We will prepend 
-    # 'RepyV2:' to the file names imported by repy.  This will serve as an 
-    # indicator that we have done this replacement (and that the traceback
-    # module should remove 2 lines from the count).
-    name = 'RepyV2:' + name
-    
 
     # Do a safety check
     try:

--- a/virtual_namespace.py
+++ b/virtual_namespace.py
@@ -64,12 +64,8 @@ class VirtualNamespace(object):
     code = code.replace('\r\n','\n')
 
     # Prepend an encoding string to protect against bugs in that code (#982).
-    # Without further fixes, prepending the encoding string causes tracebacks 
-    # to have an inaccurate line number, see SeattleTestbed/repy_v2#95.
-    # Note that we work around this in tracebackrepy.py, safe.py, and
-    # safe_check.py by retrieving the length of
-    # virtual_namespace.ENCODING_DECLARATION and subtracting it from reported
-    # line numbers.
+    # This causes tracebacks to have an inaccurate line number, so we adjust
+    # them in multiple modules. See Issue [SeattleTestbed/repy_v2#95].
     code = encoding_header.ENCODING_DECLARATION + code 
 
 


### PR DESCRIPTION
This corrects the `off-by-two' issue for exception tracebacks and data. 

Note: ut_errorlineno_codesafety.py fails due to https://github.com/SeattleTestbed/utf/issues/60

