### PR TITLE
Quick fix for #101

### DIFF
--- a/repy.py
+++ b/repy.py
@@ -331,7 +331,15 @@ def main():
   ### anywhere if this is repurposed...
   usage = "USAGE: repy.py [options] resource_file program_to_run.r2py [program args]"
   parser = optparse.OptionParser(usage=usage)
+  
+  # Set optparse to stop parsing arguments on the first non-option arg. We 
+  # need this so that command-line args to the sandboxed Repy program don't 
+  # clash or get confused with args to the sandbox (repy.py) itself.
+  # See also SeattleTestbed/repy_v2#101 .
+  # (Per the USAGE string above, the user program name is the first 
+  # non-option argument which causes parsing to stop.)
   parser.disable_interspersed_args()
+  
   add_repy_options(parser)
   options, args = parser.parse_args()
   

--- a/repy.py
+++ b/repy.py
@@ -331,6 +331,7 @@ def main():
   ### anywhere if this is repurposed...
   usage = "USAGE: repy.py [options] resource_file program_to_run.r2py [program args]"
   parser = optparse.OptionParser(usage=usage)
+  parser.disable_interspersed_args()
   add_repy_options(parser)
   options, args = parser.parse_args()
   

--- a/testsV2/ut_repyv2api_commandlineargs.py
+++ b/testsV2/ut_repyv2api_commandlineargs.py
@@ -11,7 +11,7 @@ We test this by calling repy.py with arguments similar to the above,
 and a no-op (empty) RepyV2 program. 
 If repy.py creates the named logfile, this is an error. If the file is 
 not created, we take this to mean that the sandboxed program gets the 
-argument (althoug we don't check this specifically).
+argument (although we don't check this specifically).
 
 Note: This test overwrites / removes files from the current working dir. 
 The chosen `program_name` and `logfile_prefix` should be unlikely to 

--- a/testsV2/ut_repyv2api_commandlineargs.py
+++ b/testsV2/ut_repyv2api_commandlineargs.py
@@ -1,0 +1,63 @@
+"""
+Verify that the Repy sandbox parses command-line arguments correctly.
+For example,
+  python repy.py restrictionsfile my_program.r2py --logfile ABCDEF
+
+must *not* result in the sandbox consuming the ``--logfile'' arg and 
+writing the vessel log to the named file. Instead, the sandboxed 
+program should see the arg.
+
+We test this by calling repy.py with arguments similar to the above, 
+and a no-op (empty) RepyV2 program. 
+If repy.py creates the named logfile, this is an error. If the file is 
+not created, we take this to mean that the sandboxed program gets the 
+argument (althoug we don't check this specifically).
+
+Note: This test overwrites / removes files from the current working dir. 
+The chosen `program_name` and `logfile_prefix` should be unlikely to 
+clash with anything you created, but you have been warned.
+"""
+
+import sys
+import os
+import portable_popen
+import time
+
+
+# Create an empty RepyV2 program. Remove any previous file of this name first.
+program_name = "noop_program_for_repy_callarg_test.r2py"
+try:
+  os.remove(program_name)
+except OSError:
+  # The file wasn't there. No problem.
+  pass
+
+noop_prog = open(program_name, "w")
+noop_prog.close()
+
+
+# Call Repy. If repy.py mistakingly consumes the --logfile arg, it 
+# will create a file named logfile_prefix + ".old" (or .new if .old 
+# already existed).
+logfile_prefix = "REPY_CALLARG_TEST"
+repy_process = portable_popen.Popen([sys.executable, "repy.py", 
+    "restrictions.default", program_name, "--logfile", logfile_prefix])
+
+# Give things time to settle (launching of subprocess, code safety check, etc.)
+time.sleep(5)
+
+# See if the logfile was created. 
+for filename in os.listdir("."):
+  if filename.startswith(logfile_prefix):
+    print "Found file", filename, "which indicates that repy.py consumed "
+    print "the argument meant for the sandboxed program. Bad."
+    break
+
+
+# Finally, remove any files we might created
+for filename in [program_name, logfile_prefix+".old", logfile_prefix+".new"]:
+  try:
+    os.remove(filename)
+  except OSError:
+    pass
+


### PR DESCRIPTION
Make `repy.py` stop interpreting command-line arguments once it sees
the first non-option (which is usually the name of the program to run
in the sandbox).