### PR TITLE
Add configuration for CI: Travis-CI and AppVeyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,61 @@
+# <~> Travis integration file.
+# Seattle supports Python 2.5 through 2.7, per https://seattle.poly.edu/wiki/ProgrammersPage
+# Travis provides OS X and Linux (think generally Debian-based) OS instances.
+# AppVeyor provides Windows
+
+matrix:
+  include:
+    - language: python          # Language to initiate linux VM
+      python: '2.7'             # Type of python to use     
+      os: linux                 # The OS of the VM
+      install:                  # tool installation 
+        - sudo apt-get update
+        - sudo apt-get install net-tools
+    - language: python
+      python: '2.6'
+      os: linux
+      install:
+        - sudo apt-get update
+        - sudo apt-get install net-tools
+    - language: python
+      python: '2.5'
+      os: linux
+      install:
+        - sudo apt-get update
+        - sudo apt-get install net-tools
+
+
+    # OS X Instances follow
+    # Here, we are using objective-c as currently there is no MAC + PYTHON combination available by default
+    # We instead use objective-c to install the python version we want
+    # OS X Python current version (currently 2.7.11)
+    - language: objective-c
+      os: osx
+      install:
+          brew update;
+          brew install python;
+    # OS X python 2.5.6
+    - language: objective-c
+      os: osx
+      install:
+          brew update;
+          brew install pyenv;
+          pyenv install 2.5.6;
+          pyenv global 2.5.6;
+    # OS X python 2.6.9
+    - language: objective-c
+      os: osx
+      install:
+          brew update;
+          brew install python;
+          pyenv install 2.5.6;
+          pyenv global 2.5.6;
+
+script:
+  - python --version
+  - cd ./scripts
+  - python initialize.py
+  - python build.py -t
+  - cd ../RUNNABLE
+  - python utf.py -a
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,10 @@ matrix:
       install:
         sudo add-apt-repository "ppa:fkrull/deadsnakes" -y;
         sudo apt-get update;
-        sudo mv /usr/bin/python /usr/bin/python_old;
+        #sudo mv /usr/bin/python /usr/bin/python_old;
         sudo apt-get install python2.5;
-        sudo ln -s /usr/bin/python2.5 /usr/bin/python;
-        ls -la /usr/bin/python;
+        #sudo ln -s /usr/bin/python2.5 /usr/bin/python;
+        #ls -la /usr/bin/python;
 
     # OS X Instances follow
     # There is no OS X + PYTHON combination available by default, so we
@@ -67,10 +67,9 @@ matrix:
         #brew install python26;
         pyenv install 2.6.9;
         pyenv global 2.6.9;
-        ls -la /Users/travis/.pyenv/versions/2.6.9/bin;
+        #ls -la /Users/travis/.pyenv/versions/2.6.9/bin;
 
 script:
-  - if [ "$Python" == "2.6.9" ]; then pyenv global 2.6.9; fi;
   - $PythonBin --version;
   - cd ./scripts;
   - $PythonBin initialize.py;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
-# <~> Travis integration file.
+# Travis integration file.
 # Seattle supports Python 2.5 through 2.7, per https://seattle.poly.edu/wiki/ProgrammersPage
 # Travis provides OS X and Linux (think generally Debian-based) OS instances.
-# AppVeyor provides Windows
 
 matrix:
   include:
+    # Linux Instances follow, one for each dash.
     - language: python          # Language to initiate linux VM
-      python: '2.7'             # Type of python to use     
+      python: '2.7'             # Version of python to use
       os: linux                 # The OS of the VM
-      install:                  # tool installation 
+      install:                  # tool installation
         - sudo apt-get update
         - sudo apt-get install net-tools
     - language: python
@@ -48,8 +48,8 @@ matrix:
       install:
           brew update;
           brew install python;
-          pyenv install 2.5.6;
-          pyenv global 2.5.6;
+          pyenv install 2.6.9;
+          pyenv global 2.6.9;
 
 script:
   - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@
 # The result of this configuration will be six separate builds on
 # Travis-CI VMs, 3 python versions each on Linux and OS X.
 
+# Because of some manual fiddling to get python 2.5 tests to work,
+# we require the following directive - we need non-container-based
+# infrastructure so that Travis allows us to use sudo.
+sudo: required
 
 matrix:
   include:
@@ -13,22 +17,30 @@ matrix:
     - language: python          # Language to initiate linux VM
       python: '2.7'             # Version of python to use
       os: linux                 # The OS of the VM
+      env: Python='2.7' PythonBin="python"
       install:                  # tool installation
-        - sudo apt-get update
-        - sudo apt-get install net-tools
+        sudo apt-get update;
+
     - language: python
       python: '2.6'
       os: linux
+      env: Python='2.6' PythonBin="python"
       install:
-        - sudo apt-get update
-        - sudo apt-get install net-tools
-    - language: python
-      python: '2.5'
-      os: linux
-      install:
-        - sudo apt-get update
-        - sudo apt-get install net-tools
+        sudo apt-get update;
 
+    # Because Travis-CI no longer offers the 2.5 environment by default,
+    # we'll manually install 2.5.... It's not even available on the common
+    # ubuntu repos, so we'll use deadsnakes.
+    - language: python
+      os: linux
+      env: Python='2.5' PythonBin="/usr/bin/python2.5"
+      install:
+        sudo add-apt-repository "ppa:fkrull/deadsnakes" -y;
+        sudo apt-get update;
+        sudo mv /usr/bin/python /usr/bin/python_old;
+        sudo apt-get install python2.5;
+        sudo ln -s /usr/bin/python2.5 /usr/bin/python;
+        ls -la /usr/bin/python;
 
     # OS X Instances follow
     # There is no OS X + PYTHON combination available by default, so we
@@ -41,31 +53,28 @@ matrix:
     # OS X Python current version (currently 2.7.11)
     - language: generic
       os: osx
+      env: Python='2.7' PythonBin="python"
       install:
-          brew update;
+          #brew update;
           brew install python;
-    # OS X python 2.5.6
-    - language: generic
-      os: osx
-      install:
-          brew update;
-          brew install pyenv;
-          pyenv install 2.5.6;
-          pyenv global 2.5.6;
+
     # OS X python 2.6.9
     - language: generic
       os: osx
+      env: Python='2.6.9' PythonBin="/Users/travis/.pyenv/versions/2.6.9/bin/python"
       install:
-          brew update;
-          brew install python;
-          pyenv install 2.6.9;
-          pyenv global 2.6.9;
+        #brew update;
+        #brew install python26;
+        pyenv install 2.6.9;
+        pyenv global 2.6.9;
+        ls -la /Users/travis/.pyenv/versions/2.6.9/bin;
 
 script:
-  - python --version
-  - cd ./scripts
-  - python initialize.py
-  - python build.py -t
-  - cd ../RUNNABLE
-  - python utf.py -a
+  - if [ "$Python" == "2.6.9" ]; then pyenv global 2.6.9; fi;
+  - $PythonBin --version;
+  - cd ./scripts;
+  - $PythonBin initialize.py;
+  - $PythonBin build.py -t;
+  - cd ../RUNNABLE;
+  - $PythonBin utf.py -a;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 # Travis integration file.
-# Seattle supports Python 2.5 through 2.7, per https://seattle.poly.edu/wiki/ProgrammersPage
-# Travis provides OS X and Linux (think generally Debian-based) OS instances.
+# Seattle supports Python 2.5 through 2.7, per
+#   seattle.poly.edu/wiki/ProgrammersPage
+#
+# Travis provides OS X and Linux (specifically Ubuntu) OS instances.
+# The result of this configuration will be six separate builds on
+# Travis-CI VMs, 3 python versions each on Linux and OS X.
+
 
 matrix:
   include:
@@ -26,16 +31,21 @@ matrix:
 
 
     # OS X Instances follow
-    # Here, we are using objective-c as currently there is no MAC + PYTHON combination available by default
-    # We instead use objective-c to install the python version we want
+    # There is no OS X + PYTHON combination available by default, so we
+    # use the "language: generic" directive and we'll install python
+    # ourselves through some install directives.
+    # See references:
+    #   github.com/travis-ci/travis-ci/issues/2312
+    #   docs.travis-ci.com/user/languages/python
+    #   docs.travis-ci.com/user/multi-os/#Python-example-%28unsupported-languages%29
     # OS X Python current version (currently 2.7.11)
-    - language: objective-c
+    - language: generic
       os: osx
       install:
           brew update;
           brew install python;
     # OS X python 2.5.6
-    - language: objective-c
+    - language: generic
       os: osx
       install:
           brew update;
@@ -43,7 +53,7 @@ matrix:
           pyenv install 2.5.6;
           pyenv global 2.5.6;
     # OS X python 2.6.9
-    - language: objective-c
+    - language: generic
       os: osx
       install:
           brew update;

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,7 @@ matrix:
       install:
         sudo add-apt-repository "ppa:fkrull/deadsnakes" -y;
         sudo apt-get update;
-        #sudo mv /usr/bin/python /usr/bin/python_old;
         sudo apt-get install python2.5;
-        #sudo ln -s /usr/bin/python2.5 /usr/bin/python;
-        #ls -la /usr/bin/python;
 
     # OS X Instances follow
     # There is no OS X + PYTHON combination available by default, so we
@@ -67,7 +64,6 @@ matrix:
         #brew install python26;
         pyenv install 2.6.9;
         pyenv global 2.6.9;
-        #ls -la /Users/travis/.pyenv/versions/2.6.9/bin;
 
 script:
   - $PythonBin --version;

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,13 @@
 #   seattle.poly.edu/wiki/ProgrammersPage
 #
 # Travis provides OS X and Linux (specifically Ubuntu) OS instances.
-# The result of this configuration will be six separate builds on
-# Travis-CI VMs, 3 python versions each on Linux and OS X.
+# The result of this configuration will be five separate builds on
+# Travis-CI VMs, 3 python versions on Linux and 2 on OS X.
 
-# Because of some manual fiddling to get python 2.5 tests to work,
-# we require the following directive - we need non-container-based
-# infrastructure so that Travis allows us to use sudo.
+# Primarily because of some manual fiddling to get python 2.5 tests
+# to work, we require the following directive - we need
+# non-container-based infrastructure so that Travis allows us to use
+# sudo.
 sudo: required
 
 matrix:
@@ -17,7 +18,9 @@ matrix:
     - language: python          # Language to initiate linux VM
       python: '2.7'             # Version of python to use
       os: linux                 # The OS of the VM
-      env: Python='2.7' PythonBin="python"
+      env: Python='2.7' PythonBin="python" # These are environment variables we'll use.
+        # In particular, PythonBin will specify the location of the python binary to use.
+        # The "Python" env variable there is redundant except for OS X runs below.
       install:                  # tool installation
         sudo apt-get update;
 
@@ -30,7 +33,7 @@ matrix:
 
     # Because Travis-CI no longer offers the 2.5 environment by default,
     # we'll manually install 2.5.... It's not even available on the common
-    # ubuntu repos, so we'll use deadsnakes.
+    # ubuntu repos, so we'll use the well-known deadsnakes repo.
     - language: python
       os: linux
       env: Python='2.5' PythonBin="/usr/bin/python2.5"
@@ -56,15 +59,23 @@ matrix:
           brew install python;
 
     # OS X python 2.6.9
+    # We have to use pyenv to compile and install Python 2.6.9
+    # ourselves for OS X, as Travis-CI offers no OS X Python
+    # environments, and homebrew no longer offers a python26
+    # recipe.
     - language: generic
       os: osx
       env: Python='2.6.9' PythonBin="/Users/travis/.pyenv/versions/2.6.9/bin/python"
       install:
         #brew update;
-        #brew install python26;
+        #brew install python26; # This is no longer available.
         pyenv install 2.6.9;
         pyenv global 2.6.9;
 
+# These are the commands we'll run for each build, posting the python
+# version we're *really* running, initializing to obtain needed common
+# seattle projects, building the current seattle project, and running
+# the seattle unit testing framework, with all tests.
 script:
   - $PythonBin --version;
   - cd ./scripts;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,30 @@
+build: false
+
+os: Unstable
+
+environment:
+  matrix:
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.x"
+
+    - PYTHON: "C:\\Python26"
+      PYTHON_VERSION: "2.6.x"
+
+    - PYTHON: "C:\\Python25"
+      PYTHON_VERSION: "2.5.x"
+
+platform:
+- x86
+- x64
+
+test_script:
+  - "python --version"
+  - "cd scripts"
+  - "python initialize.py"
+  - "python build.py -t"
+  - "cd ../RUNNABLE"
+  - "python utf.py -a"
+
+
+skip_commits:
+  message: /(Update README*|Created.*\.(png|jpg|jpeg|bmp|gif))/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,20 @@
+# Seattle supports Python 2.5 through 2.7, per https://seattle.poly.edu/wiki/ProgrammersPage
+# AppVeyor provides Windows-based testing.
+
 build: false
 
-os: Unstable
+# Default OS is Windows Server 2012 R2
+# As an example, uncommenting the 3 lines below would
+# result in builds being run both on the current version
+# of Windows Server 2012 R2 and the previous version of
+# Windows Server 2012 R2.
+#os:
+#  - Previous Windows Server 2012 R2
+#  - Windows Server 2012 R2
 
 environment:
   matrix:
+    # Run on each of the following three Python setups.
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7.x"
 
@@ -13,10 +24,13 @@ environment:
     - PYTHON: "C:\\Python25"
       PYTHON_VERSION: "2.5.x"
 
+# Run on 32-bit and 64-bit platforms.
 platform:
-- x86
-- x64
+  - x86
+  - x64
 
+# Execute the following sequence of commands for a given
+# build.
 test_script:
   - "python --version"
   - "cd scripts"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 # Seattle supports Python 2.5 through 2.7, per https://seattle.poly.edu/wiki/ProgrammersPage
 # AppVeyor provides Windows-based testing.
+# On Windows, we currently test on Python 2.6 and 2.7.
 
 build: false
 
@@ -21,23 +22,26 @@ environment:
     - PYTHON: "C:\\Python26"
       PYTHON_VERSION: "2.6.x"
 
-    - PYTHON: "C:\\Python25"
-      PYTHON_VERSION: "2.5.x"
+    # AppVeyor no longer supports Python 2.5 by default. If necessary, we can
+    # try to figure out how to get it running, but it is not currently a
+    # priority.
+    #- PYTHON: "C:\\Python25"
+    #  PYTHON_VERSION: "2.5.x"
 
 # Run on 32-bit and 64-bit platforms.
 platform:
   - x86
-  - x64
+  #- x64
 
 # Execute the following sequence of commands for a given
 # build.
 test_script:
-  - "python --version"
+  - "%PYTHON%\\python --version"
   - "cd scripts"
-  - "python initialize.py"
-  - "python build.py -t"
+  - "%PYTHON%\\python initialize.py"
+  - "%PYTHON%\\python build.py -t"
   - "cd ../RUNNABLE"
-  - "python utf.py -a"
+  - "%PYTHON%\\python utf.py -a"
 
 
 skip_commits:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,11 @@
 # Seattle supports Python 2.5 through 2.7, per https://seattle.poly.edu/wiki/ProgrammersPage
 # AppVeyor provides Windows-based testing.
 # On Windows, we currently test on Python 2.6 and 2.7.
+# The result of the current configuration should be 4 runs:
+#   32bit platform, Python 2.6
+#   64bit platform, Python 2.6
+#   32bit platform, Python 2.7
+#   64bit platform, Python 2.7
 
 build: false
 
@@ -15,7 +20,7 @@ build: false
 
 environment:
   matrix:
-    # Run on each of the following three Python setups.
+    # Run on each of the following two Python setups.
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7.x"
 
@@ -28,13 +33,15 @@ environment:
     #- PYTHON: "C:\\Python25"
     #  PYTHON_VERSION: "2.5.x"
 
-# Run on 32-bit and 64-bit platforms.
+# Run each on 32-bit and 64-bit platforms.
 platform:
   - x86
-  #- x64
+  - x64
 
-# Execute the following sequence of commands for a given
-# build.
+# These are the commands we'll run for each build, posting the python
+# version we're *really* running, initializing to obtain needed common
+# seattle projects, building the current seattle project, and running
+# the seattle unit testing framework, with all tests.
 test_script:
   - "%PYTHON%\\python --version"
   - "cd scripts"


### PR DESCRIPTION
The addition of these .travis.yml and appveyor.yml files here configures Travis-CI and AppVeyor to run automated tests for each push to the repository.

An explanation of CI setup and configuration is currently available [here](https://github.com/SeattleTestbed/seattlelib_v2/wiki/Continuous-Integration-for-the-Team).

You can see the build results here:
- Travis-CI: https://travis-ci.org/SeattleTestbed/repy_v2
- AppVeyor: https://ci.appveyor.com/project/SeattleTestbed/repy-v2-twqvv