### PR TITLE
Fixes signature-docstring inconsistency in sendmessage

### DIFF
--- a/emulcomm.py
+++ b/emulcomm.py
@@ -794,12 +794,12 @@ def sendmessage(destip, destport, message, localip, localport):
 
    <Arguments>
       destip:
-         The host to send a message to
+         The IP to send the message to
       destport:
          The port to send the message to
       message:
          The message to send
-      localhost:
+      localip:
          The local IP to send the message from 
       localport:
          The local port to send the message from


### PR DESCRIPTION
Changes "host" to "IP" in sendmessage's docstring to provide consistency with the function's signature.