### PR TITLE
Fix for #115 - CheckNode/StrException Messages

### DIFF
--- a/safe.py
+++ b/safe.py
@@ -254,7 +254,8 @@ def _check_node(node):
     # Don't allow the construction of unicode literals
     if type(value) == unicode:
       raise exception_hierarchy.CheckStrException("Unsafe string '" +
-          str(value) + "' in line " + str(node.lineno - HEADERSIZE))
+          str(value) + "' in line " + str(node.lineno - HEADERSIZE) +
+          ", node attribute '" + str(attribute) + "'")
 
     if attribute in _NODE_ATTR_OK: 
       continue
@@ -267,7 +268,8 @@ def _check_node(node):
     # Check the safety of any strings
     if not _is_string_safe(value):
       raise exception_hierarchy.CheckStrException("Unsafe string '" +
-          str(value) + "' in line " + str(node.lineno - HEADERSIZE))
+          str(value) + "' in line " + str(node.lineno - HEADERSIZE) +
+          ", node attribute '" + str(attribute) + "'")
 
   for child in node.getChildNodes():
     _check_node(child)

--- a/safe.py
+++ b/safe.py
@@ -247,14 +247,14 @@ def _check_node(node):
   # Proceed with the node check.
 
   if node.__class__.__name__ not in _NODE_CLASS_OK:
-    raise exception_hierarchy.CheckNodeException(node.lineno - HEADERSIZE,
-      node.__class__.__name__)
+    raise exception_hierarchy.CheckNodeException("Unsafe call '" +
+        str(node.__class__.__name__) + "' in line " + str(node.lineno - HEADERSIZE))
   
   for attribute, value in node.__dict__.iteritems():
     # Don't allow the construction of unicode literals
     if type(value) == unicode:
-      raise exception_hierarchy.CheckStrException(node.lineno - HEADERSIZE,
-        attribute, value)
+      raise exception_hierarchy.CheckStrException("Unsafe string '" +
+          str(value) + "' in line " + str(node.lineno - HEADERSIZE))
 
     if attribute in _NODE_ATTR_OK: 
       continue
@@ -264,11 +264,10 @@ def _check_node(node):
       ['Module', 'Function', 'Class']):
       continue
 
-
     # Check the safety of any strings
     if not _is_string_safe(value):
-      raise exception_hierarchy.CheckStrException(node.lineno - HEADERSIZE,
-        attribute, value)
+      raise exception_hierarchy.CheckStrException("Unsafe string '" +
+          str(value) + "' in line " + str(node.lineno - HEADERSIZE))
 
   for child in node.getChildNodes():
     _check_node(child)

--- a/testsV2/ut_errorlineno_codesafety.r2py
+++ b/testsV2/ut_errorlineno_codesafety.r2py
@@ -1,5 +1,5 @@
 #pragma repy
-#pragma out (6, 'Import')
+#pragma out "Unsafe call \'Import\' in line 6"
 
 """This unit test raises a code safety error on line 6. We do this to verify 
 that traceback line numbers are correct."""


### PR DESCRIPTION
Adds better messages for CheckNode/StrException as suggested in issue #115.
Exceptions can be triggered by doing one of the following in r2py code
```Python
# Raises exception_hierarchy.CheckNodeException
import anything

# Raises exception_hierarchy.CheckStrException
unsafe = u"Look, I want to be a unicode!"

# Raises exception_hierarchy.CheckStrException
func_unsafe = "My name is unsafe."
```

To be merged with fixes for issue #95