### PR TITLE
fixes issue97 recursion depth reached for repr(_context)

### DIFF
--- a/safe.py
+++ b/safe.py
@@ -735,6 +735,14 @@ class SafeDict(UserDict.DictMixin):
   def copy(self):
     # Create a new instance
     copy_inst = SafeDict(self.__under__)
+    
+    # Fix for recursion depth reached issue #97 when copying and printing a   
+    # SafeDict containing a reference to itself.
+    # Caveat: dict.copy is expected to return a shallow copy, this fix 
+    # introduces a partial deep copy for the contained self reference
+    for key, value in self.__under__.iteritems():
+      if value is self:
+        copy_inst[key] = copy_inst
 
     # Return the new instance
     return copy_inst

--- a/safe.py
+++ b/safe.py
@@ -735,10 +735,11 @@ class SafeDict(UserDict.DictMixin):
   def copy(self):
     # Create a new instance
     copy_inst = SafeDict(self.__under__)
-    
-    # Fix for recursion depth reached issue #97 when copying and printing a   
+
+    # Fix for recursion depth reached when copying and printing a
     # SafeDict containing a reference to itself.
-    # Caveat: dict.copy is expected to return a shallow copy, this fix 
+    # https://github.com/SeattleTestbed/repy_v2/issues/97
+    # Caveat: dict.copy is expected to return a shallow copy, this fix
     # introduces a partial deep copy for the contained self reference
     for key, value in self.__under__.iteritems():
       if value is self:

--- a/testsV2/ut_repy2api_copycontext.py
+++ b/testsV2/ut_repy2api_copycontext.py
@@ -1,10 +1,15 @@
 """
-Check that copy and repr of _context SafeDict don't result in inifinite loop
+Check that copy and repr of _context SafeDict don't result in infinite loop
 """
 #pragma repy
 
-# Create an almost shallow copy of _context
-# Contained self-reference is moved from _context to _context_copy
+# Create an "almost" shallow copy of _context, i.e. the contained reference
+# to _context is not copied as such but is changed to reference the new
+# _context_copy.
+# In consequence repr immediately truncates the contained self-reference
+# ("{...}") to prevent an infinite loop.
+# Caveat: In a real shallow copy, repr would only truncate the context
+# contained in the contained context (3rd level).
 _context_copy = _context.copy()
 repr(_context)
 repr(_context_copy)

--- a/testsV2/ut_repy2api_copycontext.py
+++ b/testsV2/ut_repy2api_copycontext.py
@@ -1,0 +1,10 @@
+"""
+Check that copy and repr of _context SafeDict don't result in inifinite loop
+"""
+#pragma repy
+
+# Create an almost shallow copy of _context
+# Contained self-reference is moved from _context to _context_copy
+_context_copy = _context.copy()
+repr(_context)
+repr(_context_copy)


### PR DESCRIPTION
Fixes recursion depth reached issue #97 when copying and printing a SafeDict containing a reference to itself. 
Caveat: dict.copy is expected to return a shallow copy, this fix introduces a partial deep copy for the contained self reference. I.e. when copy encounters a self-reference it also creates a self-reference in the newly created dictionary, instead of copying the reference to the original dict.

_This is how it should be:_

``` python
_context = { # A SafeDict
  "getmyip": <function ...>, # Reference to a function
  # ...and the rest of the API.
  "_context": _context # Reference to containing _context
}
_context_copy = _context.copy() # Return a shallow copy of _context
_context_copy = { # A new SafeDict
    "getmyip": <function ...>, # Reference to a function 
        # ...and the rest of the API.
    "_context": _context # Reference to original _context
}
```

Expected output of `repr(_context_copy)`:

``` python
{
    "getmyip": <function ...>, # repr(of referenced function)
    "_context": { # Not truncated because it references other variable
        "getmyip": <function ...>, # repr(of referenced function),
         # ...and the rest of the API.
        "_context": {...} # Python repr truncates here to prevent infinite loop
    }
}
```

_This is how it is after this patch:_

``` python
_context_copy = _context.copy() # Return a shallow/deep copy of _context
_context_copy = { # A new SafeDict
    "getmyip": <function ...>, # Reference to a function 
     # ...and the rest of the API.
    "_context": _context_copy   # !!! Reference to _context_copy
}
```

Output of `repr(_context_copy)` is now:

``` python
{
    "getmyip": <function ...>, # repr(of referenced function)
    "_context": {...} # Python immediately truncates
}
```
