### PR TITLE
Fix #71, complete API namespace wrapping

### DIFF
--- a/namespace.py
+++ b/namespace.py
@@ -351,6 +351,16 @@ class StrOrInt(ValueProcessor):
 
 
 
+class StrOrNone(ValueProcessor):
+  """Allows str, unicode, or None."""
+
+  def check(self, val):
+    if val is not None:
+      Str().check(val)
+
+
+
+
 
 class Float(ValueProcessor):
   """Allows float, int, or long."""
@@ -675,6 +685,10 @@ USERCONTEXT_WRAPPER_INFO = {
       {'func' : nonportable.get_resources,
        'args' : [],
        'return' : (Dict(), Dict(), List())},
+  'getlasterror' :
+      {'func' : emulmisc.getlasterror,
+       'args' : [],
+       'return' : StrOrNone()},
 }
 
 FILE_OBJECT_WRAPPER_INFO = {

--- a/namespace.py
+++ b/namespace.py
@@ -572,7 +572,7 @@ class VirtualNamespace(ObjectProcessor):
 
 
 
-class SafeDict(ObjectProcessor):
+class SafeDict(ValueProcessor):
   """Allows SafeDict objects."""
 
   # TODO: provide a copy function that won't actually copy so that
@@ -585,7 +585,7 @@ class SafeDict(ObjectProcessor):
 
 
 
-class DictOrSafeDict(ObjectProcessor):
+class DictOrSafeDict(ValueProcessor):
   """Allows SafeDict objects or regular dict objects."""
 
   # TODO: provide a copy function that won't actually copy so that

--- a/repy.py
+++ b/repy.py
@@ -76,7 +76,6 @@ from exception_hierarchy import *
 
 # BAD: REMOVE these imports after we remove the API calls
 #import emulfile
-import emulmisc
 #import emultimer
 
 # Disables safe, and resumes normal fork
@@ -123,7 +122,6 @@ def get_safe_context(args):
   #usercontext["sleep"] = emultimer.sleep
   #usercontext["getthreadname"] = emulmisc.getthreadname
   usercontext["createvirtualnamespace"] = virtual_namespace.createvirtualnamespace
-  usercontext["getlasterror"] = emulmisc.getlasterror
       
   # call the initialize function
   usercontext['callfunc'] = 'initialize'

--- a/repy.py
+++ b/repy.py
@@ -110,7 +110,6 @@ def get_safe_context(args):
   usercontext["_context"] = usercontext
 
   # BAD:REMOVE all API imports
-  usercontext["getresources"] = nonportable.get_resources
   #usercontext["openfile"] = emulfile.emulated_open
   #usercontext["listfiles"] = emulfile.listfiles
   #usercontext["removefile"] = emulfile.removefile

--- a/repy.py
+++ b/repy.py
@@ -74,9 +74,6 @@ import tracebackrepy
 
 from exception_hierarchy import *
 
-# BAD: REMOVE these imports after we remove the API calls
-#import emulfile
-#import emultimer
 
 # Disables safe, and resumes normal fork
 def nonSafe_fork():
@@ -109,18 +106,6 @@ def get_safe_context(args):
   # Allow some introspection by providing a reference to the context
   usercontext["_context"] = usercontext
 
-  # BAD:REMOVE all API imports
-  #usercontext["openfile"] = emulfile.emulated_open
-  #usercontext["listfiles"] = emulfile.listfiles
-  #usercontext["removefile"] = emulfile.removefile
-  #usercontext["exitall"] = emulmisc.exitall
-  #usercontext["createlock"] = emulmisc.createlock
-  #usercontext["getruntime"] = emulmisc.getruntime
-  #usercontext["randombytes"] = emulmisc.randombytes
-  #usercontext["createthread"] = emultimer.createthread
-  #usercontext["sleep"] = emultimer.sleep
-  #usercontext["getthreadname"] = emulmisc.getthreadname
-      
   # call the initialize function
   usercontext['callfunc'] = 'initialize'
   usercontext['callargs'] = args[:]

--- a/repy.py
+++ b/repy.py
@@ -120,7 +120,6 @@ def get_safe_context(args):
   #usercontext["createthread"] = emultimer.createthread
   #usercontext["sleep"] = emultimer.sleep
   #usercontext["getthreadname"] = emulmisc.getthreadname
-  usercontext["createvirtualnamespace"] = virtual_namespace.createvirtualnamespace
       
   # call the initialize function
   usercontext['callfunc'] = 'initialize'

--- a/testsV2/ut_repyv2api_getresourcescopieslimitsdict.r2py
+++ b/testsV2/ut_repyv2api_getresourcescopieslimitsdict.r2py
@@ -13,7 +13,10 @@ limits, usage, stoptimes = getresources()
 allowed_ports = limits["connport"]
 
 
-# Try to add an unprivileged port that wasn't allowed before
+# Try to add an unprivileged port that wasn't allowed before.
+# Assuming that we get only a copy of the ports list that 
+# `nanny.py` uses, we can add whatever we want, but this doesn't 
+# grant us any additional rights.
 for new_port in xrange(1024, 65536):
   if new_port not in allowed_ports:
     allowed_ports.add(new_port)

--- a/testsV2/ut_repyv2api_getresourcescopieslimitsdict.r2py
+++ b/testsV2/ut_repyv2api_getresourcescopieslimitsdict.r2py
@@ -1,0 +1,33 @@
+"""Ensure that the `getresources` call returns a copy of the `limits` 
+dict (and not the original dict), thereby ensuring that user code can 
+inspect but not modify the resource restrictions that `nanny.py` enforces.
+
+We check this by trying to add a new, previously disallowed `connport` 
+and then using it. If the port is still not allowed, all is fine.
+"""
+#pragma repy
+limits, usage, stoptimes = getresources()
+
+# This is the set of allowed TCP ports. (We should see only a *copy* 
+# of the set that `nanny` uses.)
+allowed_ports = limits["connport"]
+
+
+# Try to add an unprivileged port that wasn't allowed before
+for new_port in xrange(1024, 65536):
+  if new_port not in allowed_ports:
+    allowed_ports.add(new_port)
+    break
+else:
+  log("Premature error: All unprivileged ports are allowed already!\n")
+
+
+# Verify that we are still not allowed to use the newly added port
+try:
+  listen_socket = listenforconnection("127.0.0.1", new_port)
+except ResourceForbiddenError:
+  # This is the expected, correct error. (Any other exceptions are neither.)
+  pass
+else:
+  log("Bad: User code succeeded adding a port to the set of allowed connports and use it!\n")
+

--- a/testsV2/ut_repyv2api_virtualnamespacecontextsafety.py
+++ b/testsV2/ut_repyv2api_virtualnamespacecontextsafety.py
@@ -1,21 +1,29 @@
 """
-This unit test checks that VirtualNamespace.evaluate() forbids an unsafe context.
+Verify that VirtualNamespace.evaluate() forbids an unsafe `context`.
+
+Specifically, the `context` that a VirtualNamespace object receives 
+must be a `SafeDict`, or parseable as one. This means that the 
+context's keys must be of type `str` (which we try to violate in this 
+test), avoid particular names / prefixes / components, etc.
+
+Using an unsafe context should raise a `ContextUnsafeError` when 
+evaluatinig the VirtualNamespace.
+
+See `safe.py` for what exactly a `SafeDict` is and isn't allowed to 
+do and to contain.
 """
 
 #pragma repy 
 
-# Small code snippet
-code = "log('Bad!')\n"
+# Create a virtual namespace with an empty piece of code and a telling name
+vn = createvirtualnamespace("", "Bad VN")
 
-# Get a VN
-VN = createvirtualnamespace(code, "Bad VN")
-
-# Create a malicious context
-context = {"__metaclass__":str}
+# Create a malicious context. (Its key should be `str`, not `int`.)
+context = {123: 456}
 
 # Try to evaluate this
 try:
-  VN.evaluate(context)
+  vn.evaluate(context)
 except ContextUnsafeError:
   pass
 else:


### PR DESCRIPTION
This bunch of commits removes the last *unwrapped namespace overrides* from `repy.py` for RepyV2 API functions `getlasterror`, `createvirtualnamespace`, and `getresources`. This fixes a problematic bug in the last function in particular, see 0a69e7393ce5134b47c24f33d2cc420ac18f6eee and 48aa0a0b8b18de89d6e3e2b1cc6364dedcce4de4.