### PR TITLE
Fix #58, socket assertions in unit tests

### DIFF
--- a/testsV2/ut_repyv2api_connectionsendwilleventuallyblock.py
+++ b/testsV2/ut_repyv2api_connectionsendwilleventuallyblock.py
@@ -21,23 +21,22 @@ assert(ip == localip)
 assert(port == localport)
 
 
-# shouldn't be able to buffer more than thins
+# shouldn't be able to buffer more than this
 MAXSENDSIZE = 1024*1024
 
-# send until it would block
+# Send until the socket would block or the full message has been sent
 totalamountsent = 0
-while True:
+while totalamountsent < MAXSENDSIZE:
   try:
     amountsent = conn.send('h'*(MAXSENDSIZE-totalamountsent))
   except SocketWouldBlockError:
     # This should happen at some point.
     break
   
-  assert(amountsent > 0)
-
   totalamountsent = totalamountsent + amountsent
 
-  assert(MAXSENDSIZE != totalamountsent)
+  assert MAXSENDSIZE >= totalamountsent, "Could send more bytes than the message contained"
+
 
 
 totalamountrecvd = 0

--- a/testsV2/ut_repyv2api_connectionserversendblocks.py
+++ b/testsV2/ut_repyv2api_connectionserversendblocks.py
@@ -21,23 +21,21 @@ assert(ip == localip)
 assert(port == localport)
 
 
-# shouldn't be able to buffer more than thins
+# shouldn't be able to buffer more than this
 MAXSENDSIZE = 1024*1024
 
-# send until it would block
+# Send until the socket would block or the full message has been sent
 totalamountsent = 0
-while True:
+while totalamountsent < MAXSENDSIZE:
   try:
     amountsent = serverconn.send('h'*(MAXSENDSIZE-totalamountsent))
   except SocketWouldBlockError:
     # This should happen at some point.
     break
   
-  assert(amountsent > 0)
-
   totalamountsent = totalamountsent + amountsent
 
-  assert(MAXSENDSIZE != totalamountsent)
+  assert MAXSENDSIZE >= totalamountsent, "Could send more bytes than the message contained"
 
 
 totalamountrecvd = 0

--- a/testsV2/ut_repyv2api_listenclosesend.py
+++ b/testsV2/ut_repyv2api_listenclosesend.py
@@ -27,23 +27,21 @@ tcpserversocket.close()
 
 # now let's test the client socket...
 
-# shouldn't be able to buffer more than thins
+# shouldn't be able to buffer more than this
 MAXSENDSIZE = 1024*1024
 
-# send until it would block
+# Send until the socket would block or the full message has been sent
 totalamountsent = 0
-while True:
+while totalamountsent < MAXSENDSIZE:
   try:
     amountsent = conn.send('h'*(MAXSENDSIZE-totalamountsent))
   except SocketWouldBlockError:
     # This should happen at some point.
     break
   
-  assert(amountsent > 0)
-
   totalamountsent = totalamountsent + amountsent
 
-  assert(MAXSENDSIZE != totalamountsent)
+  assert MAXSENDSIZE >= totalamountsent, "Could send more bytes than the message contained"
 
 
 totalamountrecvd = 0


### PR DESCRIPTION
This commit addresses certain assertions and assumptions that three
unit tests had / made about the RepyV2 API. In particular,
- We cannot assume that a socket necessarily blocks and raises a
  `SocketWouldBlockError` when we use it (due to the socket buffer
  potentially swallowing/regurgitating large messages en bloc).
- Therefore, the logic to loop around sending/receiving must include
  an alternative terminal condition. (Here, we check whether we've sent
  the full message already.)
- Assertions must not depend on behavior that is not present in the
  current API implementation. (For instance, `socket.send` may report
  0 for the number of bytes sent.)
- Lastly, assertion expressions must be designed with care.
  (Obviously, checking for non-equality is not the same as checking for
  larger-than-or-equal-to.)

Also, fix a copy-pasta'd typo in these three test cases.
