### PR TITLE
Fix #132, deadly errors from within `VirtualNamespace`

### DIFF
--- a/namespace.py
+++ b/namespace.py
@@ -1229,6 +1229,17 @@ class NamespaceAPIFunctionWrapper(object):
       raise
 
     except:
-      # Any other exception is unexpected and thus is a programming error on
+      # Code evaluated inside a `VirtualNamespace` may raise arbitrary
+      # errors, including plain Python exceptions. Reraise these errors
+      # so that the calling user code sees them.
+      # (Otherwise, things like `NameError`s in a virtual namespace
+      # crash the sandbox despite being wrapped in `try`/`except`,
+      # see SeattleTestbed/repy_v2#132.)
+      if type(args[0]) == virtual_namespace.VirtualNamespace:
+        raise
+
+      # Non-`RepyException`s outside of `VirtualNamespace` methods
+      # are unexpected and indicative of a programming error on
       # our side, so we terminate.
       _handle_internalerror("Unexpected exception from within Repy API", 843)
+

--- a/testsV2/ut_repyv2api_virtualnamespace_innernameerror.r2py
+++ b/testsV2/ut_repyv2api_virtualnamespace_innernameerror.r2py
@@ -1,0 +1,23 @@
+#pragma repy
+#pragma out All is good! We caught the inner exception just fine.
+"""
+Create a virtual namespace that raises a `NameError` when `evaluate`d.
+Check that this "inner" error can be caugt in the surrounding context.
+
+See SeattleTestbed/repy_v2#132 for reference.
+"""
+# This piece of code should raise a `NameError: name 'x' is not defined`.
+# (Doing the `raise` directly would also work.)
+code = "x"
+
+# Creating the namespace is no problem -- no SyntaxError, no safety issues
+virtualnamespace = createvirtualnamespace(code, "NameError test")
+
+try:
+  virtualnamespace.evaluate({})
+except NameError:
+  # This is the expected result. Stay quiet, everything's alright!
+  pass
+
+log("All is good! We caught the inner exception just fine.\n")
+


### PR DESCRIPTION
This commit fixes an issue in `namespace.py`'s handling of the
wrapped `evaluate` method of `virtual_namespace.VirtualNamespace`.
`namespace.py` previously assumed that all RepyV2 API calls will
only ever raise `RepyException`s (or subclasses thereof). Since
PR #127 made virtual namespaces wrapped objects, the earlier
assumption is invalid: A virtual namespace can raise plain Python
exceptions (like `NameError`s) as well!

We therefore add a `VirtualNamespace`-specific clause for handling
Python exceptions raised by `NamespaceAPIFunctionWrapper.wrapped_function`s:
If a Python exception is seen, and it originates from an object of
type `VirtualNamespace`, then we reraise the exception so that
user code can see and handle it. For other origins, consider the
Python exception an indication of a programming error in the sandbox
API definitions, and terminate the sandbox.

This commit also adds a unit test that raises a `NameError` inside
of a `VirtualNamespace` to demonstrate the problem and its fix.