### PR TITLE
Fix #137, issue references in comments

### DIFF
--- a/emulcomm.py
+++ b/emulcomm.py
@@ -56,16 +56,16 @@ from exception_hierarchy import *
 
 ###### Module Data
 
-# This is a library of all currently bound sockets. Since multiple 
+# This is a dictionary of all currently bound sockets. Since multiple 
 # UDP bindings on a single port is hairy, we store bound sockets 
 # here, and use them for both sending and receiving if they are 
 # available. This feels slightly byzantine, but it allows us to 
-# avoid modifying the repy API.
+# avoid modifying the repy API. See also SeattleTestbed/repy_v2#9.
 #
 # Format of entries is as follows:
 # Key - 3-tuple of ("UDP", IP, Port)
 # Val - Bound socket object
-_BOUND_SOCKETS = {} # Ticket = 1015 (Resolved)
+_BOUND_SOCKETS = {}
 
 # If we have a preference for an IP/Interface this flag is set to True
 user_ip_interface_preferences = False
@@ -706,7 +706,7 @@ def _get_localIP_to_remoteIP(connection_type, external_ip, external_port=80):
   sockobj = socket.socket(socket.AF_INET, connection_type)
 
   # Make sure that the socket obj doesn't hang forever in 
-  # case connect() is blocking. Fix to #1003
+  # case connect() is blocking. Fix to SeattleTestbed/repy_v2#7.
   sockobj.settimeout(1.0)
 
   try:
@@ -1810,7 +1810,7 @@ class EmulatedSocket:
         raise KeyError # Socket is closed locally
  
       # Detect Socket Closed Remote
-      # Fixes ticket#974
+      # Fixes SeattleTestbed/repy_v2#4.
       (readable, writable, exception) = select.select([sock],[],[],0)
       # check if socket is readable.   This is true if the remote end closed.
       if readable:

--- a/emulfile.py
+++ b/emulfile.py
@@ -29,9 +29,9 @@ import repy_constants
 # Import all the exceptions
 from exception_hierarchy import *
 
-# Fix for ticket #983. By retaining a reference to unicode, we prevent
-# os.path.abspath from failing in some versions of python when the unicode
-# builtin is overwritten.
+# Fix for SeattleTestbed/ATTIC#983.
+# By retaining a reference to unicode, we prevent os.path.abspath from
+# failing in some versions of python when the unicode builtin is overwritten.
 os.path.unicode = unicode
 
 # Store a reference to open, so that we retain access

--- a/resourcemanipulation.py
+++ b/resourcemanipulation.py
@@ -175,7 +175,7 @@ def parse_resourcedict_from_string(resourcestring):
         raise ResourceParseError("Line '"+line+"' has an unknown resource '"+knownresourcename+"'")
 
       # and the last item should be a valid float or int, 
-      # depending on the resource type (#1374)
+      # depending on the resource type (SeattleTestbed/repy_v2#59)
       try:
         # Renewable resources should be cast as floats
         if knownresourcename in resource_constants.renewable_resources:
@@ -387,7 +387,7 @@ def subtract_resourcedicts(dict1, dict2):
     if resource not in retdict:
       retdict[resource] = 0.0
 
-    # ... if it's a float, we can just subtract...
+    # ... if it's a numeric value, we can just subtract...
     if type(retdict[resource]) in [float, int]:
       retdict[resource] = retdict[resource] - dict2[resource]
 

--- a/safe.py
+++ b/safe.py
@@ -108,13 +108,14 @@ import exception_hierarchy # For exception classes
 import encoding_header # Subtract len(ENCODING_HEADER) from error line numbers.
 
 
-# Fix to make repy compatible with Python 2.7.2 on Ubuntu 11.10 (ticket #1049)
+# Fix to make repy compatible with Python 2.7.2 on Ubuntu 11.10,
+# see SeattleTestbed/repy_v2#24.
 subprocess.getattr = getattr
 
 # Armon: This is how long we will wait for the external process
 # to validate the safety of the user code before we timeout, 
 # and exit with an exception
-# AR: Increasing timeout to 15 seconds, see r3410 / #744
+# Increased from 10 to 15 seconds per SeattleTestbed/repy_v1#90.
 EVALUTATION_TIMEOUT = 15
 
 if platform.machine().startswith('armv'):
@@ -260,7 +261,8 @@ def _check_node(node):
     if attribute in _NODE_ATTR_OK: 
       continue
 
-    # JAC: don't check doc strings for __ and the like... (#889)
+    # JAC: don't check doc strings for __ and the like...,
+    # see SeattleTestbed/repy_v1#107.
     if attribute == 'doc' and (node.__class__.__name__ in
       ['Module', 'Function', 'Class']):
       continue
@@ -353,8 +355,9 @@ def safe_check_subprocess(code):
   proc.stdout.close()
 
 
-  # Interim fix for #1080: Get rid of stray debugging output on Android
-  # of the form "dlopen libpython2.6.so" and "dlopen /system/lib/libc.so",
+  # Interim fix for SeattleTestbed/ATTIC#1080:
+  # Get rid of stray debugging output on Android of the form
+  # `dlopen libpython2.6.so` and `dlopen /system/lib/libc.so`,
   # yet preserve all of the other output (including empty lines).
 
   if IS_ANDROID:
@@ -449,7 +452,7 @@ def safe_type(*args, **kwargs):
     raise exception_hierarchy.RunBuiltinException(
       'type() may only take exactly one non-keyword argument.')
 
-  # Fix for #1189
+  # Fix for SeattleTestbed/repy_v1#128, block access to `type`.
 #  if _type(args[0]) is _type or _type(args[0]) is _compile_type:
 #    raise exception_hierarchy.RunBuiltinException(
 #      'unsafe type() call.')
@@ -734,8 +737,9 @@ class SafeDict(UserDict.DictMixin):
     # Return the safe keys
     return safe_keys
 
-  # allow us to be printed
-  # this gets around the __repr__ infinite loop issue ( #918 ) for simple cases
+  # Allow us to be printed.
+  # Overriding __repr__ gets around an infinite loop issue,
+  # SeattleTestbed/repy_v1#111, for simple cases.
   # It seems unlikely this is adequate for more complex cases (like safedicts
   # that refer to each other)
   def __repr__(self):

--- a/safe.py
+++ b/safe.py
@@ -82,8 +82,8 @@ import os           # This is for some path manipulation
 import sys          # This is to get sys.executable to launch the external process
 import time         # This is to sleep
 
-# Currently required to filter out Android-specific debug messages, cf #1080
-# and safe_check() below
+# Currently required to filter out Android-specific debug messages,
+# see SeattleTestbed/ATTIC#1080 and safe_check() below.
 try:
   import android
   IS_ANDROID = True
@@ -167,7 +167,8 @@ _STR_NOT_CONTAIN = ['__']
 _STR_NOT_BEGIN = ['im_','func_','tb_','f_','co_',]
 
 # Disallow these exact strings.
-#   encode and decode are not allowed because of the potential for encoding bugs (#982) 
+# encode and decode are not allowed because of the potential for
+# encoding bugs, see SeattleTestbed/repy_v1#120.
 _STR_NOT_ALLOWED = ['encode','decode'] 
 
 def _is_string_safe(token):
@@ -241,8 +242,8 @@ def _check_node(node):
   <Return>
     None
   """
-  # Subtract length of encoding header from traceback line numbers.
-  # (See Issue [SeattleTestbed/repy_v2#95])
+  # Subtract length of encoding header from traceback line numbers,
+  # see SeattleTestbed/repy_v2#95.
   HEADERSIZE = len(encoding_header.ENCODING_DECLARATION.splitlines())
 
   # Proceed with the node check.
@@ -452,7 +453,7 @@ def safe_type(*args, **kwargs):
     raise exception_hierarchy.RunBuiltinException(
       'type() may only take exactly one non-keyword argument.')
 
-  # Fix for SeattleTestbed/repy_v1#128, block access to `type`.
+  # Fix for SeattleTestbed/repy_v1#128, block access to Python's `type`.
 #  if _type(args[0]) is _type or _type(args[0]) is _compile_type:
 #    raise exception_hierarchy.RunBuiltinException(
 #      'unsafe type() call.')

--- a/safe_check.py
+++ b/safe_check.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     value = safe.safe_check(usercode)
     output += str(value)
   except Exception, e:
-    # Adjust traceback line numbers. See Issue [SeattleTestbed/repy_v2#95].
+    # Adjust traceback line numbers, see SeattleTestbed/repy_v2#95.
     try:
       e.lineno = e.lineno - \
           len(encoding_header.ENCODING_DECLARATION.splitlines())

--- a/virtual_namespace.py
+++ b/virtual_namespace.py
@@ -63,9 +63,10 @@ class VirtualNamespace(object):
     # Remove any windows carriage returns
     code = code.replace('\r\n','\n')
 
-    # Prepend an encoding string to protect against bugs in that code (#982).
+    # Prepend an encoding string to protect against bugs in that code,
+    # see SeattleTestbed/repy_v1#120.
     # This causes tracebacks to have an inaccurate line number, so we adjust
-    # them in multiple modules. See Issue [SeattleTestbed/repy_v2#95].
+    # them in multiple modules. See SeattleTestbed/repy_v2#95.
     code = encoding_header.ENCODING_DECLARATION + code 
 
 


### PR DESCRIPTION
This set of commits addresses #137 by making uniform all issue references in comments in the `repy_v2` code base. (I used the org--repo--issue format throughout, see also secure-systems-lab/code-style-guidelines#12.)

Please **squash-merge** this PR if you're happy with it. The separate commits are not terribly interesting, I just tried (and failed!) to go file-by-file.

BTW, here is how I found issue references in the code:
```
grep "#[0-9]" *
grep -i ticket *   # Trac called these things "tickets"
grep -i issue *    # This is the name we use now/on GitHub
```
